### PR TITLE
feat: add javascriptFile property (The same as styleSheetFile property but for js files)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Here some simple styles were added to every `h1` & `h2` tags within the `div` wh
   ngxPrint>print</button>
 
 ```
-- If you want to customize the printing window with additional scripts (JS) by importing the js provided in assets/js or in a cdn use `javascriptFile`:
+If you want to customize the printing window with additional scripts (JS) by importing the js provided in assets/js or in a cdn use `javascriptFile`:
 
 
 ```html

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Here some simple styles were added to every `h1` & `h2` tags within the `div` wh
   ngxPrint>print</button>
 
 ```
--  If you want to customize the printing window with additional scripts (JS) by importing the js provided in assets/js or in a cdn use `javascriptFile`:
+- If you want to customize the printing window with additional scripts (JS) by importing the js provided in assets/js or in a cdn use `javascriptFile`:
 
 
 ```html

--- a/README.md
+++ b/README.md
@@ -128,6 +128,23 @@ Here some simple styles were added to every `h1` & `h2` tags within the `div` wh
   ngxPrint>print</button>
 
 ```
+- If you want to customize the printing window with additional scripts (JS) by importing the js provided in assets/js or in a cdn use `javascriptFile`:
+
+
+```html
+
+<div  id="print-section">
+
+<!-- ... -->
+
+</div>
+
+<button
+  javascriptFile="assets/js/custom1.js,assets/js/custom2.js"
+  printSectionId="print-section"
+  ngxPrint>print</button>
+
+```
 ## Contributors :1st_place_medal: 
 
 Huge thanks to: [deeplotia](https://github.com/deeplotia) , [Ben L](https://github.com/broem) , [Gavyn McKenzie](https://github.com/gavmck) , [silenceway](https://github.com/silenceway), [Muhammad Ahsan Ayaz](https://github.com/AhsanAyaz) and to all  `ngx-print` users 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Here some simple styles were added to every `h1` & `h2` tags within the `div` wh
   ngxPrint>print</button>
 
 ```
-- If you want to customize the printing window with additional scripts (JS) by importing the js provided in assets/js or in a cdn use `javascriptFile`:
+-  If you want to customize the printing window with additional scripts (JS) by importing the js provided in assets/js or in a cdn use `javascriptFile`:
 
 
 ```html

--- a/src/lib/ngx-print.directive.ts
+++ b/src/lib/ngx-print.directive.ts
@@ -73,6 +73,15 @@ public returnStyleValues() {
   private _styleSheetFile = '';
 
   /**
+   *
+   *
+   * @returns html for the given tag
+   *
+   * @memberof NgxPrintDirective
+   */
+  private _javascriptFile = '';
+
+  /**
    * @memberof NgxPrintDirective
    * @param cssList
    */
@@ -92,6 +101,25 @@ public returnStyleValues() {
   }
 
   /**
+   * @memberof NgxPrintDirective
+   * @param jsList
+   */
+  @Input()
+  set javascriptFile(jsList: string) {
+    let linkTagFn = function(jsFileName) {
+      return `<script src="${jsFileName}">`;
+    }
+    if (jsList.indexOf(',') !== -1) {
+      const valueArr = jsList.split(',');
+      for (let val of valueArr) {
+        this._javascriptFile = this._javascriptFile + linkTagFn(val);
+      }
+    } else {
+      this._javascriptFile = linkTagFn(jsList);
+    }
+  }
+
+  /**
    * @returns string which contains the link tags containing the css which will
    * be injected later within <head></head> tag.
    *
@@ -99,6 +127,16 @@ public returnStyleValues() {
   private returnStyleSheetLinkTags() {
     return this._styleSheetFile;
   }
+
+  /**
+   * @returns string which contains the script tags containing the js which will
+   * be injected later within <head></head> tag.
+   *
+   */
+  private returnJavascriptLinkTags() {
+    return this._javascriptFile;
+  }
+
   private getElementTag(tag: keyof HTMLElementTagNameMap): string {
     const html: string[] = [];
     const elements = document.getElementsByTagName(tag);
@@ -144,6 +182,7 @@ public returnStyleValues() {
           <title>${this.printTitle ? this.printTitle : ""}</title>
           ${this.returnStyleValues()}
           ${this.returnStyleSheetLinkTags()}
+          ${this.returnJavascriptLinkTags()}
           ${styles}
           ${links}
         </head>


### PR DESCRIPTION
Hello,
I am using `ngx-print` with Ionic+Angular, and I figured out that the `<ion-icon></ion-icon>` element was not being rendered, because of the missing ionicons's javascript file:
`<script src="https://unpkg.com/ionicons@5.1.2/dist/ionicons.js"></script>`
Therefore, I decided to add the possibility for users being able to add scripts to the printing window page just like it is possible to do with the stylesheets. I really need these icons on my prints, but I don't know for sure yet how can I get this new version of 'ngx-print' into my project, I'll be waiting for your response.