### PR TITLE
  Fix print style bugs and add raw CSS string support for printStyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ export class PrintExampleComponent {}
 
 Here some simple styles were added to every `h1` & `h2` tags within the `div` where `print-section` is tagged to its `id` attribute.
 
+`printStyle` also accepts a raw CSS string, which is injected into the print document's `<style>` tag as-is. This is useful for anything the object form can't express well, such as multiple selectors per rule, media queries, or `!important`:
+
+```html
+<button printStyle="h1, h2 { color: red; } @media print { .no-print { display: none; } }"
+        printSectionId="print-section"
+        ngxPrint>print</button>
+```
+
 - If you would like to use your existing CSS with media print you can add the `useExistingCss` attribute:
 
 ```html
@@ -246,6 +254,9 @@ printDelay: number = 0;
 ```ts
 // Optional: CSS as a key-value pair
 this.printService.printStyle = styleSheet;
+
+// Optional: CSS as a raw string
+this.printService.printStyle = 'h1, h2 { color: red; }';
 
 // Optional: path to a CSS file
 this.printService.styleSheetFile = fileLocation;

--- a/src/lib/ngx-print.base.ts
+++ b/src/lib/ngx-print.base.ts
@@ -9,6 +9,12 @@ import { PrintOptions } from './print-options';
  *   */
 export type PrintStyle = Record<string, Record<string, string>>;
 
+/**
+ * Either a {@link PrintStyle} object, or a raw CSS string (e.g. `'h1 { color: red; }'`)
+ * to be injected into the print document's <style> tag as-is.
+ */
+export type PrintStyleInput = PrintStyle | string;
+
 @Service()
 export class PrintBase {
   private document = inject(DOCUMENT);
@@ -23,10 +29,15 @@ export class PrintBase {
   /**
    * Sets the print styles based on the provided values.
    *
-   * @param {Object} values - Key-value pairs representing print styles.
+   * @param values - Either a key-value pairs object representing print styles, or a raw CSS string.
    * @protected
    */
-  protected setPrintStyle(values: PrintStyle) {
+  protected setPrintStyle(values: PrintStyleInput) {
+    if (typeof values === 'string') {
+      this._printStyle = values ? [values] : [];
+      return;
+    }
+
     this._printStyle = [];
     for (const [selector, declarations] of Object.entries(values)) {
       // Built declaration-by-declaration (rather than via JSON.stringify + a quote-stripping

--- a/src/lib/ngx-print.base.ts
+++ b/src/lib/ngx-print.base.ts
@@ -189,7 +189,7 @@ export class PrintBase {
     this.syncFormValues(sourceElm, cloneElm);
     this.updateCanvasToImage(sourceElm, cloneElm);
 
-    return cloneElm.innerHTML;
+    return cloneElm.outerHTML;
   }
 
   /**

--- a/src/lib/ngx-print.base.ts
+++ b/src/lib/ngx-print.base.ts
@@ -28,22 +28,24 @@ export class PrintBase {
    */
   protected setPrintStyle(values: PrintStyle) {
     this._printStyle = [];
-    for (const key of Object.keys(values)) {
-      this._printStyle.push((key + JSON.stringify(values[key])).replace(/['"]+/g, ''));
+    for (const [selector, declarations] of Object.entries(values)) {
+      // Built declaration-by-declaration (rather than via JSON.stringify + a quote-stripping
+      // regex) so that quotes and commas that are part of a CSS value (e.g. quoted font names,
+      // comma-separated font-family fallback lists) survive instead of being stripped/mangled.
+      const body = Object.entries(declarations)
+        .map(([property, value]) => `${property}:${value}`)
+        .join(';');
+      this._printStyle.push(`${selector}{${body}}`);
     }
   }
 
   /**
-   *
-   *
    * @returns the string that create the stylesheet which will be injected
    * later within <style></style> tag.
-   *
-   * -join/replace to transform an array objects to css-styled string
    */
   public returnStyleValues(): string {
     const styleNonce = this.nonce ? ` nonce="${this.nonce}"` : '';
-    return `<style${styleNonce}> ${this._printStyle.join(' ').replace(/,/g, ';')} </style>`;
+    return `<style${styleNonce}> ${this._printStyle.join(' ')} </style>`;
   }
 
   /**

--- a/src/lib/ngx-print.directive.spec.ts
+++ b/src/lib/ngx-print.directive.spec.ts
@@ -105,6 +105,22 @@ describe('NgxPrintDirective', () => {
     expect(directive.returnStyleValues()).toEqual('<style> h2{border:solid 1px} h1{color:red;border:1px solid} </style>');
   });
 
+  it('should preserve quotes and commas within style values', async () => {
+    vi.spyOn(window, 'open');
+    component.printStyle.set({
+      'li::before': { content: '"→"' },
+      'p': { 'font-family': '"Helvetica Neue", Arial, sans-serif', color: 'red' },
+    });
+    await fixture.whenStable();
+
+    const directive = buttonEl.injector.get(NgxPrintDirective);
+    buttonEl.triggerEventHandler('click', {});
+
+    expect(directive.returnStyleValues()).toEqual(
+      '<style> li::before{content:"→"} p{font-family:"Helvetica Neue", Arial, sans-serif;color:red} </style>',
+    );
+  });
+
   it(`should popup a new window`, () => {
     vi.spyOn(window, 'open');
     // simulate click

--- a/src/lib/ngx-print.directive.spec.ts
+++ b/src/lib/ngx-print.directive.spec.ts
@@ -7,7 +7,7 @@ import { PrintStyle, PrintStyleInput } from './ngx-print.base';
 
 @Component({
   template: `
-    <div id="print-section">
+    <div id="print-section" style="border: 2px solid red;">
       <h1>Welcome to ngx-print</h1>
       <img
         width="300"
@@ -164,6 +164,35 @@ describe('NgxPrintDirective', () => {
     buttonEl.triggerEventHandler('click', {});
 
     expect(mockDocument.body.classList.contains('theme-dark')).toBe(true);
+  });
+
+  it('should preserve the print section root element attributes (e.g. style)', () => {
+    const body = {
+      className: '',
+      classList: { contains: () => false },
+      innerHTML: '',
+      appendChild: vi.fn(),
+    };
+    const mockDocument = {
+      body,
+      open: vi.fn(),
+      close: vi.fn(),
+      head: { appendChild: vi.fn(), innerHTML: '' },
+      appendChild: vi.fn(),
+      createElement: (tag: string) => (tag === 'body' ? body : { innerHTML: '', appendChild: vi.fn(), textContent: '' }),
+    };
+    const mockWindow = {
+      document: mockDocument,
+      closed: true,
+      addEventListener: vi.fn(),
+    };
+    vi.spyOn(window, 'open').mockReturnValue(mockWindow as unknown as Window);
+
+    buttonEl.triggerEventHandler('click', {});
+
+    // The print section's own id and inline style must survive (not just its children's).
+    expect(mockDocument.body.innerHTML).toContain('id="print-section"');
+    expect(mockDocument.body.innerHTML).toContain('border: 2px solid red');
   });
 
   it('should emit printComplete when printing finishes', () => {

--- a/src/lib/ngx-print.directive.spec.ts
+++ b/src/lib/ngx-print.directive.spec.ts
@@ -3,7 +3,7 @@ import { Component, DebugElement, provideZonelessChangeDetection, signal } from 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NgxPrintDirective } from './ngx-print.directive';
-import { PrintStyle } from './ngx-print.base';
+import { PrintStyle, PrintStyleInput } from './ngx-print.base';
 
 @Component({
   template: `
@@ -41,7 +41,7 @@ import { PrintStyle } from './ngx-print.base';
   imports: [NgxPrintDirective],
 })
 class TestNgxPrintComponent {
-  readonly printStyle = signal<PrintStyle>({});
+  readonly printStyle = signal<PrintStyleInput>({});
 }
 
 describe('NgxPrintDirective', () => {
@@ -119,6 +119,17 @@ describe('NgxPrintDirective', () => {
     expect(directive.returnStyleValues()).toEqual(
       '<style> li::before{content:"→"} p{font-family:"Helvetica Neue", Arial, sans-serif;color:red} </style>',
     );
+  });
+
+  it('should accept a raw CSS string for printStyle', async () => {
+    vi.spyOn(window, 'open');
+    component.printStyle.set('h1, h2 { color: red; }');
+    await fixture.whenStable();
+
+    const directive = buttonEl.injector.get(NgxPrintDirective);
+    buttonEl.triggerEventHandler('click', {});
+
+    expect(directive.returnStyleValues()).toEqual('<style> h1, h2 { color: red; } </style>');
   });
 
   it(`should popup a new window`, () => {

--- a/src/lib/ngx-print.directive.ts
+++ b/src/lib/ngx-print.directive.ts
@@ -1,5 +1,5 @@
 import { Directive, input, output } from '@angular/core';
-import { PrintBase, PrintStyle } from './ngx-print.base';
+import { PrintBase, PrintStyleInput } from './ngx-print.base';
 import { PrintOptions } from './print-options';
 import { take } from 'rxjs';
 
@@ -42,7 +42,7 @@ export class NgxPrintDirective extends PrintBase {
    */
   readonly printMethod = input<PrintOptions['printMethod']>('window');
 
-  readonly printStyle = input<PrintStyle>({});
+  readonly printStyle = input<PrintStyleInput>({});
 
   readonly styleSheetFile = input('');
 

--- a/src/lib/ngx-print.service.spec.ts
+++ b/src/lib/ngx-print.service.spec.ts
@@ -195,6 +195,19 @@ describe('NgxPrintService', () => {
     );
   });
 
+  it('should accept a raw CSS string for printStyle', () => {
+    service.printStyle = 'h1, h2 { color: red; }';
+
+    expect(service.returnStyleValues()).toEqual('<style nonce="' + testNonce + '"> h1, h2 { color: red; } </style>');
+  });
+
+  it('should clear the style when printStyle is set to an empty string', () => {
+    service.printStyle = 'h1 { color: red; }';
+    service.printStyle = '';
+
+    expect(service.returnStyleValues()).toEqual('<style nonce="' + testNonce + '">  </style>');
+  });
+
   it('should emit on print completion (void)', () => {
     vi.useFakeTimers();
     const body = {

--- a/src/lib/ngx-print.service.spec.ts
+++ b/src/lib/ngx-print.service.spec.ts
@@ -184,6 +184,17 @@ describe('NgxPrintService', () => {
     expect(service.returnStyleValues()).toEqual('<style nonce="' + testNonce + '"> h2{border:solid 1px} h1{color:red;border:1px solid} </style>');
   });
 
+  it('should preserve quotes and commas within style values', () => {
+    service.printStyle = {
+      'li::before': { content: '"→"' },
+      'p': { 'font-family': '"Helvetica Neue", Arial, sans-serif', color: 'red' },
+    };
+
+    expect(service.returnStyleValues()).toEqual(
+      '<style nonce="' + testNonce + '"> li::before{content:"→"} p{font-family:"Helvetica Neue", Arial, sans-serif;color:red} </style>',
+    );
+  });
+
   it('should emit on print completion (void)', () => {
     vi.useFakeTimers();
     const body = {

--- a/src/lib/ngx-print.service.spec.ts
+++ b/src/lib/ngx-print.service.spec.ts
@@ -10,7 +10,7 @@ const testNonce = 'dummy-nonce-value';
 
 @Component({
   template: `
-    <div id="print-section">
+    <div id="print-section" style="border: 2px solid red;">
       <h1>Welcome to ngx-print</h1>
       <img
         width="300"
@@ -206,6 +206,35 @@ describe('NgxPrintService', () => {
     service.printStyle = '';
 
     expect(service.returnStyleValues()).toEqual('<style nonce="' + testNonce + '">  </style>');
+  });
+
+  it('should preserve the print section root element attributes (e.g. style)', () => {
+    const body = {
+      className: '',
+      classList: { contains: () => false },
+      innerHTML: '',
+      appendChild: vi.fn(),
+    };
+    const mockDocument = {
+      body,
+      open: vi.fn(),
+      close: vi.fn(),
+      head: { appendChild: vi.fn(), innerHTML: '' },
+      appendChild: vi.fn(),
+      createElement: (tag: string) => (tag === 'body' ? body : { innerHTML: '', appendChild: vi.fn(), textContent: '' }),
+    };
+    const mockWindow = {
+      document: mockDocument,
+      closed: true,
+      addEventListener: vi.fn(),
+    };
+    vi.spyOn(window, 'open').mockReturnValue(mockWindow as unknown as Window);
+
+    component.printMe(new PrintOptions({ printSectionId: 'print-section' }));
+
+    // The print section's own id and inline style must survive (not just its children's).
+    expect(mockDocument.body.innerHTML).toContain('id="print-section"');
+    expect(mockDocument.body.innerHTML).toContain('border: 2px solid red');
   });
 
   it('should emit on print completion (void)', () => {

--- a/src/lib/ngx-print.service.ts
+++ b/src/lib/ngx-print.service.ts
@@ -1,5 +1,5 @@
 import { Service } from '@angular/core';
-import { PrintBase, PrintStyle } from './ngx-print.base';
+import { PrintBase, PrintStyleInput } from './ngx-print.base';
 import { PrintOptions } from './print-options';
 
 /**
@@ -29,11 +29,11 @@ export class NgxPrintService extends PrintBase {
   /**
    * Sets the print style for the printing process.
    *
-   * @param {{ [key: string]: { [key: string]: string } }} values - A dictionary representing the print styles.
+   * @param values - Either a dictionary representing the print styles, or a raw CSS string.
    * @memberof NgxPrintService
    * @setter
    */
-  set printStyle(values: PrintStyle) {
+  set printStyle(values: PrintStyleInput) {
     super.setPrintStyle(values);
   }
 

--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -5,3 +5,4 @@ export { NgxPrintDirective } from './lib/ngx-print.directive';
 export { NgxPrintModule } from './lib/ngx-print.module';
 export { NgxPrintService } from './lib/ngx-print.service';
 export { PrintOptions } from './lib/print-options';
+export { PrintStyle, PrintStyleInput } from './lib/ngx-print.base';


### PR DESCRIPTION
- Fix: setPrintStyle() built each CSS rule via JSON.stringify + a blanket quote-strip, which mangled values needing quotes (e.g. content: "→") or commas (e.g. font-family: Arial, sans-serif). Rules are now built declaration-by-declaration so quotes/commas inside values are preserved.
- Feat: printStyle now also accepts a raw CSS string (PrintStyle | string, exported as PrintStyleInput) in addition to the existing object form, for cases the object shape can't express well
  (multi-selector rules, media queries, !important)
- Fix: getHtmlContents() returned cloneElm.innerHTML instead of outerHTML, silently dropping any id/class/inline style placed directly on the printSectionId element itself (only descendants survived). Now uses outerHTML so the section's own attributes make it into the print document
